### PR TITLE
fixed issue with actor_net initialization in Anymal example

### DIFF
--- a/examples/envs/anymal/scripts/rsl_ppo_test.py
+++ b/examples/envs/anymal/scripts/rsl_ppo_test.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
-from rslgym.wrapper import VecEnvPython  # import python wrapper interface
-from rslgym_wrapper_anymal import anymal_example_env
 import os
 import datetime
 import argparse
 from ruamel.yaml import YAML, dump, RoundTripDumper
 import numpy as np
 import torch
-import rslgym.algorithm.modules as rslgym_module
 from torch import nn
+
+import rslgym.algorithm.modules as rslgym_module
+from rslgym.wrapper import VecEnvPython  # import python wrapper interface
+from rslgym_wrapper_anymal import anymal_example_env
 
 
 def main():

--- a/examples/envs/cart_pole/scripts/pfrl_ppo_test.py
+++ b/examples/envs/cart_pole/scripts/pfrl_ppo_test.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-from rslgym.wrapper import VecEnvPython  # import python wrapper interface
-from rslgym_wrapper_cart_pole import cart_pole_example_env
 import os
 import datetime
 import argparse
@@ -11,6 +9,8 @@ import torch
 from torch import nn
 from distutils.version import LooseVersion
 
+from rslgym.wrapper import VecEnvPython  # import python wrapper interface
+from rslgym_wrapper_cart_pole import cart_pole_example_env
 import pfrl
 
 import matplotlib.pyplot as plt

--- a/examples/envs/cart_pole/scripts/rsl_ppo_test.py
+++ b/examples/envs/cart_pole/scripts/rsl_ppo_test.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-from rslgym.wrapper import VecEnvPython # import python wrapper interface
-from rslgym_wrapper_cart_pole import cart_pole_example_env
 import os
 import datetime
 import argparse
@@ -9,6 +7,8 @@ import numpy as np
 import torch
 import rslgym.algorithm.modules as rslgym_module
 from torch import nn
+from rslgym.wrapper import VecEnvPython # import python wrapper interface
+from rslgym_wrapper_cart_pole import cart_pole_example_env
 import matplotlib.pyplot as plt
 
 

--- a/examples/envs/cart_pole/scripts/rsl_ppo_train.py
+++ b/examples/envs/cart_pole/scripts/rsl_ppo_train.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-from rslgym.wrapper import VecEnvPython
-from rslgym_wrapper_cart_pole import cart_pole_example_env
 import os
 import argparse
 import time
@@ -15,6 +13,8 @@ from scipy.signal import savgol_filter
 import torch
 from torch import nn
 
+from rslgym.wrapper import VecEnvPython
+from rslgym_wrapper_cart_pole import cart_pole_example_env
 import rslgym.algorithm.modules as rslgym_module
 from rslgym.algorithm.agents.ppo import PPO
 from rslgym.algorithm.utils import ConfigurationSaver


### PR DESCRIPTION
#### Issue
The anymal example rsl_ppo_test.py file showed an error when I ran it on my Intel CPU with the error message: 
`Could not run 'aten::empty_strided' with arguments from the 'MkldnnCPU' backend.`

This error showed up at the actor_net initialization step: `rslgym_module.EmpiricalNormalization([obs_size])`

#### Solution implemented
I was able to fix this error by rearranging the import order in `rsl_ppo_test.py` so that `torch.nn` is imported before `rslgym.algorithm.module` and `rslgym.wrapper`. I am not exactly sure why the order of import caused the problem but this new order shows no more issues when I ran the example rsl_ppo_test.py. 

